### PR TITLE
fix(body): a line appears above the footer

### DIFF
--- a/src/components/commons/Layout/Layout.vue
+++ b/src/components/commons/Layout/Layout.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="has-navbar-fixed-top">
     <Header />
-    <section class="hero is-fullheight">
-      <div :class="backgroundColor" class="hero-body">
+    <section :class="backgroundColor" class="hero is-fullheight">
+      <div class="hero-body">
         <div class="section container">
           <router-view />
         </div>


### PR DESCRIPTION
A line appears above the footer and does not switch to the dark mode on mobile mode.
**Before**
![image](https://user-images.githubusercontent.com/37890026/84456226-784c6600-ac2d-11ea-8ed4-ea5eb6184587.png)
**After**
![image](https://user-images.githubusercontent.com/37890026/84456243-800c0a80-ac2d-11ea-982f-fb13f7180264.png)
